### PR TITLE
set default value and update varfile location

### DIFF
--- a/manifests/nolio_agent.pp
+++ b/manifests/nolio_agent.pp
@@ -22,7 +22,7 @@ class nolio::nolio_agent(
 
   $windows_temp_dir          = 'C:\media',
   $windows_install_dir       = "C:\\Program Files (x86)\\CA",
-  $package_src_http,
+  $package_src_http          = "",
 ){
 
 

--- a/manifests/nolio_agent_windows.pp
+++ b/manifests/nolio_agent_windows.pp
@@ -52,7 +52,7 @@ define nolio::nolio_agent_windows (
   }->
 
   file{"${src_dir}\\agent.silent.varfile":
-    content => template("nolio_agent_windows/agent.silent.varfile-v${template_version}.erb"),
+    content => template("nolio/agent.silent.varfile-v${template_version}.erb"),
     replace  => "yes",
   }->
 


### PR DESCRIPTION
In order to be backwards compatible, default value needed to be set for src_http.
Also, forgot to update the proper varfile location before merging into multifile format.
